### PR TITLE
chore: Removed rc dependancy in rsock

### DIFF
--- a/nbox/instance.py
+++ b/nbox/instance.py
@@ -218,10 +218,6 @@ class Instance():
     }
     self.__opened = True
 
-  def _prepare_for_rc(self):
-    if "app.nimblebox.ai" in self.stub_ws_instance._url:
-      self.stub_ws_instance._url = self.stub_ws_instance._url.replace("app.", "app.rc.")
-
   # def _revert_to_app(self):
   #   if "app.rc." in self.stub_ws_instance._url:
   #     self.stub_ws_instance._url = self.stub_ws_instance._url.replace("app.rc.", "app.")
@@ -324,9 +320,9 @@ class Instance():
     file_logger = FileLogger(filepath)
     logger.debug(f"Logging RSock server to {filepath}")
 
-    if "app.nimblebox.ai" in self.stub_ws_instance._url:
-      self.stub_ws_instance._url = self.stub_ws_instance._url.replace("app.", "app.rc.")
-      self._open() # open using the updated URL
+    # if "app.nimblebox.ai" in self.stub_ws_instance._url:
+    #   self.stub_ws_instance._url = self.stub_ws_instance._url.replace("app.", "app.rc.")
+    self._open() # open using the updated URL
 
     conman = ConnectionManager(
       file_logger = file_logger,

--- a/nbox/sub_utils/ssh.py
+++ b/nbox/sub_utils/ssh.py
@@ -120,7 +120,7 @@ class RSockClient:
     """
     self.log('Connecting to RSockServer', "DEBUG")
     rsock_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    rsock_socket.connect(('rsock.rc.nimblebox.ai', 886))
+    rsock_socket.connect(('rsock.nimblebox.ai', 886))
 
     if self.secure:
       self.log('Starting SSL')


### PR DESCRIPTION
This removes the dependency on `rsock.rc.nimblebox.ai`.
It connects directly to the production rsock server (`rsock.nimblebox.ai`).