### PR TITLE
fix: reference error for model resource

### DIFF
--- a/nbox/jobs.py
+++ b/nbox/jobs.py
@@ -381,7 +381,7 @@ def upload_job_folder(
         serving = Serving(id=id),
       )
     )
-
+    resource = __common_resource(serving_proto.resource)
     out: Serve = deploy_serving(
       init_folder = init_folder,
       serving_id = serving_proto.id,
@@ -559,8 +559,8 @@ class Serve:
     """
     if not self.model_id:
       raise ValueError("Model ID is required to scale a model. Pass with --model_id")
-    if replicas < 1:
-      raise ValueError("Replicas must be greater than 0")
+    if replicas < 0:
+      raise ValueError("Replicas must be greater than or equal to 0")
 
     logger.info(f"Scale model deployment {self.model_id} to {replicas} replicas")
     rpc(


### PR DESCRIPTION
Setting replicas 0 will terminate the model. We can add it to the documentation. @yashbonde 